### PR TITLE
Ft/606503 - Update library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [2.0.0] - 2026-05-20
+
+### Added
+- XML documentation (`///`) on all public members.
+- Updated `README.md` with project overview, structure, features, compatibility, and dependencies.
+
+### Changed
+- **BREAKING**: Renamed `Paginate` extension methods to `PaginateAsync` to follow async naming conventions.
+- **BREAKING**: Changed `Page<T>.Rows` from `IEnumerable<T>?` to `IReadOnlyList<T>` to prevent multiple enumerations and enforce non-null collections.
+- **BREAKING**: Replaced AutoMapper-based mapping with a projection selector (`Func<TSource, TResult>`) in `PaginateAsync`, removing the external AutoMapper dependency.
+
+### Removed
+- Removed `AutoMapper` package dependency.
+
+### Fixed
+- Fixed anti-pattern where `Task.RunSynchronously()` was used to create synchronous Tasks.
+- Fixed `.Take((page * limit)..limit)` range operator bug in `IQueryable<T>` pagination.
+- Fixed incorrect `Length` assignment when query result is empty (was passing `page` instead of `0`).
+
+## [1.1.0]
+
+### Changed
+- Updated target frameworks to include .NET 10 (`net10.0`).
+- Updated library dependencies to latest compatible versions.
+
+## [1.0.0]
+
+### Added
+- Initial release of the shared application library.
+- `FilterParams` abstract class for pagination and sorting parameters.
+- `Page<T>` generic wrapper for paginated results.
+- `PagePaginate` extension methods for `IQueryable<T>` with FluentResults integration.
+- Multi-target framework support (`net8.0`, `net9.0`).
+- NuGet package configuration with metadata, icon, and license.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# IATec.Shared.Net.Behaviors
+# IATec.Shared.Net.Application
 
-Repository for managing classes shared between .net projects developed at IATec.
+Shared library by IATec to assist in the development of .NET applications.
+
+## Purpose
+
+Provide common utility classes and wrappers for data pagination, standardizing paginated list responses across internal projects.
+
+## Structure
+
+```
+src/
+└── Wrappers/
+    ├── FilterParams.cs    # Pagination parameters (Page, Limit, OrderBy, OrderDirection)
+    ├── Page.cs            # Generic paginated result wrapper (Length, Rows)
+    └── PagePaginate.cs    # Pagination extensions for IQueryable<T>
+```
+
+## Features
+
+- **FilterParams**: abstract class with default properties for pagination and sorting.
+- **Page<T>**: wrapper for paginated results with `Length` (total records) and `Rows` (item list).
+- **PagePaginate**: extension methods for `IQueryable<T>` that:
+  - Apply pagination (`Skip`/`Take`)
+  - Support projection with a **selector function**
+  - Return results wrapped in **FluentResults.Result<T>**
+
+## Compatibility
+
+- **Target Frameworks:** `net8.0`, `net9.0`, `net10.0`
+
+## Dependencies
+
+- `FluentResults` (4.0.0)
+
+## Repository
+
+[https://github.com/iatecbr/IATec.Shared.Net.Application](https://github.com/iatecbr/IATec.Shared.Net.Application)
+
+## Changelog
+
+See [CHANGELOG.md](CHANGELOG.md) for a detailed history of changes.
+

--- a/src/IATec.Shared.Application.csproj
+++ b/src/IATec.Shared.Application.csproj
@@ -10,7 +10,7 @@
 		<Description>Project developed to help IATec teams to develop their projects faster.</Description>
 		<Copyright>@IATec Solutions</Copyright>
 		<RootNamespace>IATec.Shared.Application</RootNamespace>
-        <Version>1.1.0</Version>
+        <Version>2.0.0</Version>
         <PackageIconUrl>https://assets-services-dev.sdasystems.org/images/icons/standard.library.icon.png</PackageIconUrl>
         <PackageIcon>icon.png</PackageIcon>
         <RepositoryUrl>https://github.com/iatecbr/IATec.Shared.Net.Application</RepositoryUrl>
@@ -27,7 +27,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="AutoMapper" Version="16.0.0" />
       <PackageReference Include="FluentResults" Version="4.0.0" />
     </ItemGroup>
 </Project>

--- a/src/Wrappers/FilterParams.cs
+++ b/src/Wrappers/FilterParams.cs
@@ -1,9 +1,27 @@
 ﻿namespace IATec.Shared.Application.Wrappers;
 
+/// <summary>
+/// Abstract base class for pagination and sorting parameters.
+/// </summary>
 public abstract class FilterParams
 {
+    /// <summary>
+    /// The page index (zero-based). Default is 0.
+    /// </summary>
     public int Page { get; set; } = 0;
+
+    /// <summary>
+    /// The maximum number of items per page. Default is 20.
+    /// </summary>
     public int Limit { get; set; } = 20;
+
+    /// <summary>
+    /// The property name to order by. Default is "Id".
+    /// </summary>
     public string OrderBy { get; set; } = "Id";
+
+    /// <summary>
+    /// The sort direction: "asc" or "desc". Default is "asc".
+    /// </summary>
     public string OrderDirection { get; set; } = "asc";
 }

--- a/src/Wrappers/Page.cs
+++ b/src/Wrappers/Page.cs
@@ -1,11 +1,28 @@
 namespace IATec.Shared.Application.Wrappers;
 
+/// <summary>
+/// Represents a paginated result containing total length and the current page items.
+/// </summary>
+/// <typeparam name="T">The type of the items in the page.</typeparam>
 public class Page<T>
 {
+    /// <summary>
+    /// Total number of items across all pages.
+    /// </summary>
     public int Length { get; set; }
-    public IEnumerable<T>? Rows { get; set; }
 
-    public static Page<T> Set(int length, IEnumerable<T>? rows)
+    /// <summary>
+    /// The read-only collection of items for the current page.
+    /// </summary>
+    public IReadOnlyList<T> Rows { get; set; } = [];
+
+    /// <summary>
+    /// Creates a new <see cref="Page{T}"/> with the specified total length and rows.
+    /// </summary>
+    /// <param name="length">Total number of items.</param>
+    /// <param name="rows">Items for the current page.</param>
+    /// <returns>A new <see cref="Page{T}"/> instance.</returns>
+    public static Page<T> Set(int length, IReadOnlyList<T> rows)
     {
         return new Page<T>
         {

--- a/src/Wrappers/PagePaginate.cs
+++ b/src/Wrappers/PagePaginate.cs
@@ -1,39 +1,59 @@
-using AutoMapper;
 using FluentResults;
 
 namespace IATec.Shared.Application.Wrappers;
 
+/// <summary>
+/// Provides extension methods for paginating <see cref="IQueryable{T}"/> sequences.
+/// </summary>
 public static class PagePaginate
 {
-    public static Task<Result<Page<TOutput>>> Paginate<TInput, TOutput>(
-        this IQueryable<TInput> query,
+    /// <summary>
+    /// Paginates the query and projects the results using the specified selector.
+    /// </summary>
+    /// <typeparam name="TSource">The type of items in the source query.</typeparam>
+    /// <typeparam name="TResult">The type to project the items to.</typeparam>
+    /// <param name="query">The source query to paginate.</param>
+    /// <param name="page">The page index (zero-based).</param>
+    /// <param name="limit">The number of items per page.</param>
+    /// <param name="selector">A projection function to transform each item.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> containing a <see cref="FluentResults.Result{T}"/>
+    /// with the paginated <see cref="Page{TResult}"/>.
+    /// </returns>
+    public static Task<Result<Page<TResult>>> PaginateAsync<TSource, TResult>(
+        this IQueryable<TSource> query,
         int page,
         int limit,
-        IMapper mapper)
+        Func<TSource, TResult> selector)
     {
         var length = query.Count();
 
         if (length == 0)
         {
-            return Task.FromResult(Result.Ok(Page<TOutput>.Set(page, [])));
+            return Task.FromResult(Result.Ok(Page<TResult>.Set(0, [])));
         }
 
         var list = query
             .Skip(page * limit)
             .Take(limit)
+            .Select(selector)
             .ToList();
 
-        var finalList = mapper.Map<IEnumerable<TOutput>>(list);
-
-        var task = new Task<Result<Page<TOutput>>>(() => Result.Ok(
-            Page<TOutput>.Set(length, finalList)));
-
-        task.RunSynchronously();
-
-        return task;
+        return Task.FromResult(Result.Ok(Page<TResult>.Set(length, list)));
     }
-    
-    public static Task<Result<Page<T>>> Paginate<T>(
+
+    /// <summary>
+    /// Paginates the query without projecting the results.
+    /// </summary>
+    /// <typeparam name="T">The type of items in the query.</typeparam>
+    /// <param name="query">The source query to paginate.</param>
+    /// <param name="page">The page index (zero-based).</param>
+    /// <param name="limit">The number of items per page.</param>
+    /// <returns>
+    /// A <see cref="Task{TResult}"/> containing a <see cref="FluentResults.Result{T}"/>
+    /// with the paginated <see cref="Page{T}"/>.
+    /// </returns>
+    public static Task<Result<Page<T>>> PaginateAsync<T>(
         this IQueryable<T> query,
         int page,
         int limit)
@@ -42,18 +62,14 @@ public static class PagePaginate
 
         if (length == 0)
         {
-            return Task.FromResult(Result.Ok(Page<T>.Set(page, [])));
+            return Task.FromResult(Result.Ok(Page<T>.Set(0, [])));
         }
 
         var list = query
-            .Take((page * limit)..limit)
+            .Skip(page * limit)
+            .Take(limit)
             .ToList();
 
-        var task = new Task<Result<Page<T>>>(() => Result.Ok(
-            Page<T>.Set(length, list)));
-
-        task.RunSynchronously();
-
-        return task;
+        return Task.FromResult(Result.Ok(Page<T>.Set(length, list)));
     }
 }


### PR DESCRIPTION
## [2.0.0] - 2026-05-20

### Added
- XML documentation (`///`) on all public members.
- Updated `README.md` with project overview, structure, features, compatibility, and dependencies.

### Changed
- **BREAKING**: Renamed `Paginate` extension methods to `PaginateAsync` to follow async naming conventions.
- **BREAKING**: Changed `Page<T>.Rows` from `IEnumerable<T>?` to `IReadOnlyList<T>` to prevent multiple enumerations and enforce non-null collections.
- **BREAKING**: Replaced AutoMapper-based mapping with a projection selector (`Func<TSource, TResult>`) in `PaginateAsync`, removing the external AutoMapper dependency.

### Removed
- Removed `AutoMapper` package dependency.

### Fixed
- Fixed anti-pattern where `Task.RunSynchronously()` was used to create synchronous Tasks.
- Fixed `.Take((page * limit)..limit)` range operator bug in `IQueryable<T>` pagination.
- Fixed incorrect `Length` assignment when query result is empty (was passing `page` instead of `0`).